### PR TITLE
Fix labels for "WrenScript" and "Unit"

### DIFF
--- a/Nuake/src/Scene/Components/WrenScriptComponent.h
+++ b/Nuake/src/Scene/Components/WrenScriptComponent.h
@@ -9,7 +9,7 @@ namespace Nuake {
 		std::string Script;
 		std::string Class;
 
-		Ref<WrenScript> WrenScript;
+		Ref<WrenScript> mWrenScript;
 
 		json Serialize()
 		{

--- a/Nuake/src/Scene/Systems/ScriptingSystem.cpp
+++ b/Nuake/src/Scene/Systems/ScriptingSystem.cpp
@@ -18,15 +18,15 @@ namespace Nuake {
 			WrenScriptComponent& wren = entities.get<WrenScriptComponent>(e);
 			if (wren.Script != "" && wren.Class != "")
 			{
-				wren.WrenScript = CreateRef<WrenScript>(wren.Script, wren.Class, true);
-				if (!wren.WrenScript->CompiledSuccesfully)
+				wren.mWrenScript = CreateRef<WrenScript>(wren.Script, wren.Class, true);
+				if (!wren.mWrenScript->CompiledSuccesfully)
 					return false;
 			}
 
-			if (wren.WrenScript != nullptr)
+			if (wren.mWrenScript != nullptr)
 			{
-				wren.WrenScript->SetScriptableEntityID((int)e);
-				wren.WrenScript->CallInit();
+				wren.mWrenScript->SetScriptableEntityID((int)e);
+				wren.mWrenScript->CallInit();
 			}
 		}
 
@@ -41,8 +41,8 @@ namespace Nuake {
 		{
 			WrenScriptComponent& wren = entities.get<WrenScriptComponent>(e);
 
-			if (wren.WrenScript != nullptr)
-				wren.WrenScript->CallUpdate(ts);
+			if (wren.mWrenScript != nullptr)
+				wren.mWrenScript->CallUpdate(ts);
 		}
 	}
 
@@ -54,8 +54,8 @@ namespace Nuake {
 		{
 			WrenScriptComponent& wren = entities.get<WrenScriptComponent>(e);
 
-			if (wren.WrenScript != nullptr)
-				wren.WrenScript->CallFixedUpdate(ts);
+			if (wren.mWrenScript != nullptr)
+				wren.mWrenScript->CallFixedUpdate(ts);
 		}
 	}
 
@@ -67,8 +67,8 @@ namespace Nuake {
 		{
 			WrenScriptComponent& wren = entities.get<WrenScriptComponent>(e);
 
-			if (wren.WrenScript != nullptr)
-				wren.WrenScript->CallExit();
+			if (wren.mWrenScript != nullptr)
+				wren.mWrenScript->CallExit();
 		}
 
 		ScriptingEngine::Close();

--- a/Nuake/src/Scripting/Modules/SceneModule.h
+++ b/Nuake/src/Scripting/Modules/SceneModule.h
@@ -117,7 +117,7 @@ namespace Nuake {
 
 				if (ent.HasComponent<WrenScriptComponent>())
 				{
-					wrenSetSlotHandle(vm, 0, ent.GetComponent<WrenScriptComponent>().WrenScript->m_Instance);
+					wrenSetSlotHandle(vm, 0, ent.GetComponent<WrenScriptComponent>().mWrenScript->m_Instance);
 				}
 			}
 

--- a/Nuake/src/UI/Nodes/Node.cpp
+++ b/Nuake/src/UI/Nodes/Node.cpp
@@ -38,45 +38,45 @@ namespace Nuake
 			{
 			case PropType::HEIGHT:
 			{
-				style.Height.Unit = (Layout::Unit)(s.second.type);
+				style.Height.mUnit = (Layout::Unit)(s.second.type);
 				float value = s.second.value.Number;
 				style.Height.Value = value;
 			}
 			break;
 			case PropType::MIN_HEIGHT:
-				style.MinHeight.Unit = (Layout::Unit)s.second.type;
+				style.MinHeight.mUnit = (Layout::Unit)s.second.type;
 				style.MinHeight.Value = s.second.value.Number;
 				break;
 			case PropType::MAX_HEIGHT:
-				style.MaxHeight.Unit = (Layout::Unit)s.second.type;
+				style.MaxHeight.mUnit = (Layout::Unit)s.second.type;
 				style.MaxHeight.Value = s.second.value.Number;
 				break;
 			case PropType::WIDTH:
-				style.Width.Unit = (Layout::Unit)s.second.type;
+				style.Width.mUnit = (Layout::Unit)s.second.type;
 				style.Width.Value = s.second.value.Number;
 				break;
 			case PropType::MIN_WIDTH:
-				style.MinWidth.Unit = (Layout::Unit)s.second.type;
+				style.MinWidth.mUnit = (Layout::Unit)s.second.type;
 				style.MinWidth.Value = s.second.value.Number;
 				break;
 			case PropType::MAX_WIDTH:
-				style.MaxWidth.Unit = (Layout::Unit)s.second.type;
+				style.MaxWidth.mUnit = (Layout::Unit)s.second.type;
 				style.MaxWidth.Value = s.second.value.Number;
 				break;
 			case PropType::MARGIN_RIGHT:
-				style.Margin.Right.Unit = (Layout::Unit)s.second.type;
+				style.Margin.Right.mUnit = (Layout::Unit)s.second.type;
 				style.Margin.Right.Value = s.second.value.Number;
 				break;
 			case PropType::MARGIN_LEFT:
-				style.Margin.Left.Unit = (Layout::Unit)s.second.type;
+				style.Margin.Left.mUnit = (Layout::Unit)s.second.type;
 				style.Margin.Left.Value = s.second.value.Number;
 				break;
 			case PropType::MARGIN_TOP:
-				style.Margin.Top.Unit = (Layout::Unit)s.second.type;
+				style.Margin.Top.mUnit = (Layout::Unit)s.second.type;
 				style.Margin.Top.Value = s.second.value.Number;
 				break;
 			case PropType::MARGIN_BOTTOM:
-				style.Margin.Bottom.Unit = (Layout::Unit)s.second.type;
+				style.Margin.Bottom.mUnit = (Layout::Unit)s.second.type;
 				style.Margin.Bottom.Value = s.second.value.Number;
 				break;
 			case PropType::JUSTIFY_CONTENT:
@@ -101,19 +101,19 @@ namespace Nuake
 				style.PositionType = (Layout::PositionType)s.second.value.Enum;
 				break;
 			case PropType::LEFT:
-				style.Position.Left.Unit = (Layout::Unit)s.second.type;
+				style.Position.Left.mUnit = (Layout::Unit)s.second.type;
 				style.Position.Left.Value = s.second.value.Number;
 				break;
 			case PropType::RIGHT:
-				style.Position.Right.Unit = (Layout::Unit)s.second.type;
+				style.Position.Right.mUnit = (Layout::Unit)s.second.type;
 				style.Position.Right.Value = s.second.value.Number;
 				break;
 			case PropType::TOP:
-				style.Position.Top.Unit = (Layout::Unit)s.second.type;
+				style.Position.Top.mUnit = (Layout::Unit)s.second.type;
 				style.Position.Top.Value = s.second.value.Number;
 				break;
 			case PropType::BOTTOM:
-				style.Position.Bottom.Unit = (Layout::Unit)s.second.type;
+				style.Position.Bottom.mUnit = (Layout::Unit)s.second.type;
 				style.Position.Bottom.Value = s.second.value.Number;
 				break;
 			case PropType::BACKGROUND_COLOR:

--- a/Nuake/src/UI/Nodes/Node.h
+++ b/Nuake/src/UI/Nodes/Node.h
@@ -74,7 +74,7 @@ namespace Nuake
 			if (IsHover)
 				style = this->HoverStyle;
 
-			switch (style.Width.Unit)
+			switch (style.Width.mUnit)
 			{
 			case Layout::Unit::PIXEL:
 				YGNodeStyleSetWidth(YogaNode, style.Width.Value);
@@ -86,7 +86,7 @@ namespace Nuake
 				YGNodeStyleSetWidthAuto(YogaNode);
 				break;
 			}
-			switch (style.Height.Unit)
+			switch (style.Height.mUnit)
 			{
 			case Layout::Unit::PIXEL:
 				YGNodeStyleSetHeight(YogaNode, style.Height.Value);
@@ -99,7 +99,7 @@ namespace Nuake
 				break;
 			}
 
-			switch (style.Margin.Left.Unit)
+			switch (style.Margin.Left.mUnit)
 			{
 			case Layout::Unit::PIXEL:
 				YGNodeStyleSetMargin(YogaNode, YGEdgeLeft, style.Margin.Left.Value);
@@ -112,7 +112,7 @@ namespace Nuake
 				break;
 			}
 
-			switch (style.Margin.Right.Unit)
+			switch (style.Margin.Right.mUnit)
 			{
 			case Layout::Unit::PIXEL:
 				YGNodeStyleSetMargin(YogaNode, YGEdgeRight, style.Margin.Right.Value);
@@ -125,7 +125,7 @@ namespace Nuake
 				break;
 			}
 
-			switch (style.Margin.Top.Unit)
+			switch (style.Margin.Top.mUnit)
 			{
 			case Layout::Unit::PIXEL:
 				YGNodeStyleSetMargin(YogaNode, YGEdgeTop, style.Margin.Top.Value);
@@ -138,7 +138,7 @@ namespace Nuake
 				break;
 			}
 
-			switch (style.Margin.Bottom.Unit)
+			switch (style.Margin.Bottom.mUnit)
 			{
 			case Layout::Unit::PIXEL:
 				YGNodeStyleSetMargin(YogaNode, YGEdgeBottom, style.Margin.Bottom.Value);
@@ -150,7 +150,7 @@ namespace Nuake
 				YGNodeStyleSetMarginAuto(YogaNode, YGEdgeTop);
 				break;
 			}
-			switch (style.Padding.Left.Unit)
+			switch (style.Padding.Left.mUnit)
 			{
 			case Layout::Unit::PIXEL:
 				YGNodeStyleSetPadding(YogaNode, YGEdgeLeft, style.Padding.Left.Value);
@@ -160,7 +160,7 @@ namespace Nuake
 				break;
 			}
 
-			switch (style.Padding.Right.Unit)
+			switch (style.Padding.Right.mUnit)
 			{
 			case Layout::Unit::PIXEL:
 				YGNodeStyleSetPadding(YogaNode, YGEdgeRight, style.Padding.Right.Value);
@@ -170,7 +170,7 @@ namespace Nuake
 				break;
 			}
 
-			switch (style.Padding.Top.Unit)
+			switch (style.Padding.Top.mUnit)
 			{
 			case Layout::Unit::PIXEL:
 				YGNodeStyleSetPadding(YogaNode, YGEdgeTop, style.Padding.Top.Value);
@@ -180,7 +180,7 @@ namespace Nuake
 				break;
 			}
 
-			switch (style.Padding.Bottom.Unit)
+			switch (style.Padding.Bottom.mUnit)
 			{
 			case Layout::Unit::PIXEL:
 				YGNodeStyleSetPadding(YogaNode, YGEdgeBottom, style.Padding.Bottom.Value);
@@ -189,28 +189,28 @@ namespace Nuake
 				YGNodeStyleSetPaddingPercent(YogaNode, YGEdgeBottom, style.Padding.Bottom.Value);
 				break;
 			}
-			switch (style.Border.Left.Unit)
+			switch (style.Border.Left.mUnit)
 			{
 			case Layout::Unit::PIXEL:
 				YGNodeStyleSetBorder(YogaNode, YGEdgeLeft, style.Border.Left.Value);
 				break;
 			}
 
-			switch (style.Border.Right.Unit)
+			switch (style.Border.Right.mUnit)
 			{
 			case Layout::Unit::PIXEL:
 				YGNodeStyleSetBorder(YogaNode, YGEdgeRight, style.Border.Right.Value);
 				break;
 			}
 
-			switch (style.Border.Top.Unit)
+			switch (style.Border.Top.mUnit)
 			{
 			case Layout::Unit::PIXEL:
 				YGNodeStyleSetBorder(YogaNode, YGEdgeTop, style.Border.Top.Value);
 				break;
 			}
 
-			switch (style.Border.Bottom.Unit)
+			switch (style.Border.Bottom.mUnit)
 			{
 			case Layout::Unit::PIXEL:
 				YGNodeStyleSetBorder(YogaNode, YGEdgeBottom, style.Border.Bottom.Value);

--- a/Nuake/src/UI/Styling/Style.h
+++ b/Nuake/src/UI/Styling/Style.h
@@ -49,7 +49,7 @@ namespace Nuake
 		struct LayoutUnit
 		{
 			float Value = 0.0f;
-			Unit Unit = Unit::PIXEL;
+			Unit mUnit = Unit::PIXEL;
 		};
 
 		struct LayoutVec4


### PR DESCRIPTION
I wasn't aware MSVC allowed that, but that's a pretty nonstandard behaviour, I haven't seen any other compiler that allow a label to overshadow a type.

With every change to `main` a merge conflict to my linux branch emerges, and it's these labels. So may we change them for good?
I've added `m` in front of every label, to denote that it's not the type, it's a member of that type.

I'll be happy to do any necessary changes