### PR TITLE
Change Back-slashes to slashes, for unix compatibility

### DIFF
--- a/Nuake/src/Core/Maths.h
+++ b/Nuake/src/Core/Maths.h
@@ -1,7 +1,7 @@
 #pragma once
-#include <glm\ext\vector_float4.hpp>
-#include <glm\ext\vector_float3.hpp>
-#include <glm\ext\matrix_transform.hpp>
+#include <glm/ext/vector_float4.hpp>
+#include <glm/ext/vector_float3.hpp>
+#include <glm/ext/matrix_transform.hpp>
 #include <src/Vendors/glm/ext/vector_float2.hpp>
 #include <src/Vendors/glm/ext/matrix_float4x4.hpp>
 

--- a/Nuake/src/Rendering/Camera.cpp
+++ b/Nuake/src/Rendering/Camera.cpp
@@ -1,11 +1,11 @@
 #include "Camera.h"
 #include "src/Core/Maths.h"
 #include "../Core/Input.h"
-#include <glm\ext\vector_float3.hpp>
-#include <glm\ext\matrix_clip_space.hpp>
-#include <glm\ext\matrix_float4x4.hpp>
-#include <glm\ext\matrix_transform.hpp>
-#include <GLFW\glfw3.h>
+#include <glm/ext/vector_float3.hpp>
+#include <glm/ext/matrix_clip_space.hpp>
+#include <glm/ext/matrix_float4x4.hpp>
+#include <glm/ext/matrix_transform.hpp>
+#include <GLFW/glfw3.h>
 
 
 namespace Nuake

--- a/Nuake/src/Scene/Components/Components.h
+++ b/Nuake/src/Scene/Components/Components.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <glm\ext\matrix_float4x4.hpp>
+#include <glm/ext/matrix_float4x4.hpp>
 #include <string>
 
 #include "BaseComponent.h"

--- a/Nuake/src/Scene/Components/LightComponent.h
+++ b/Nuake/src/Scene/Components/LightComponent.h
@@ -1,13 +1,13 @@
 #pragma once
-#include <glm\ext\vector_float3.hpp>
-#include <glm\ext\vector_float2.hpp>
+#include <glm/ext/vector_float3.hpp>
+#include <glm/ext/vector_float2.hpp>
 #include "TransformComponent.h"
 #include "../Rendering/Camera.h"
 #include "src/Rendering/Buffers/Framebuffer.h"
 #include "BaseComponent.h"
 #include "../Resource/Serializable.h"
 
-#include <glm\ext\matrix_clip_space.hpp>
+#include <glm/ext/matrix_clip_space.hpp>
 
 namespace Nuake
 {

--- a/Nuake/src/Scene/Components/MeshComponent.h
+++ b/Nuake/src/Scene/Components/MeshComponent.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <glm\ext\matrix_float4x4.hpp>
+#include <glm/ext/matrix_float4x4.hpp>
 #include <vector>
 #include "src/Rendering/Mesh/Mesh.h"
 #include "src/Resource/Serializable.h"

--- a/Nuake/src/Scene/Entities/Entity.h
+++ b/Nuake/src/Scene/Entities/Entity.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <string>
-#include <glm\ext\matrix_float4x4.hpp>
+#include <glm/ext/matrix_float4x4.hpp>
 #include "../Scene.h"
 #include "../Components/BaseComponent.h"
 #include "../Resource/Serializable.h"

--- a/Nuake/src/Scene/Entities/ImGuiHelper.h
+++ b/Nuake/src/Scene/Entities/ImGuiHelper.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <string>
-#include <glm\ext\vector_float3.hpp>
+#include <glm/ext/vector_float3.hpp>
 #include <imgui/imgui.h>
 #include <imgui/imgui_stdlib.h>
 #include <imgui/imgui_internal.h>


### PR DESCRIPTION
Maths.h, Camera.cpp, Components.h, LightComponent.h, MeshComponent.h, Entity.h, ImGuiHelper.h
Changed backslashes to slashes, for unix-compatibility

Here's something cherry-picked from the Linux-port branch which tends to conflict with main.
In Unix-like systems, backslashes are only escape symbols, forward slashes are part of the path.
I don't think MSVC cares, since a lot of the newer code does seem to use forward slashes.