### PR TITLE
Creating New Project doesn't add .project

### DIFF
--- a/Editor/src/Windows/EditorInterface.cpp
+++ b/Editor/src/Windows/EditorInterface.cpp
@@ -1248,7 +1248,7 @@ namespace Nuake {
 
     void NewProject()
     {
-        if (Engine::GetProject() && Engine::GetProject()->Exist())
+        if (Engine::GetProject() && Engine::GetProject()->FileExist())
             Engine::GetProject()->Save();
         
         std::string selectedProject = FileDialog::SaveFile("Project file\0*.project");

--- a/Editor/src/Windows/EditorInterface.cpp
+++ b/Editor/src/Windows/EditorInterface.cpp
@@ -1248,14 +1248,18 @@ namespace Nuake {
 
     void NewProject()
     {
-        if (Engine::GetProject())
+        if (Engine::GetProject() && Engine::GetProject()->Exist())
             Engine::GetProject()->Save();
-
+        
         std::string selectedProject = FileDialog::SaveFile("Project file\0*.project");
-        if (selectedProject == "") // Hit cancel
+        
+        if(!String::EndsWith(selectedProject, ".project"))
+            selectedProject += ".project";
+        
+        if (selectedProject.empty()) // Hit cancel
             return;
-
-        Ref<Project> project = Project::New("Unnamed project", "no description", selectedProject + ".project");
+        
+        Ref<Project> project = Project::New("Unnamed project", "no description", selectedProject);
         Engine::LoadProject(project);
         Engine::LoadScene(Scene::New());
     }

--- a/Editor/src/Windows/WelcomeWindow.cpp
+++ b/Editor/src/Windows/WelcomeWindow.cpp
@@ -166,28 +166,31 @@ namespace Nuake
 				if (ImGui::Button("New Project", buttonSize))
 				{
 					std::string selectedProject = FileDialog::SaveFile("Project file\0*.project");
-
+					
 					if (!selectedProject.empty())
 					{
+						if(!String::EndsWith(selectedProject, ".project"))
+							selectedProject += ".project";
+						
 						auto backslashSplits = String::Split(selectedProject, '\\');
 						auto fileName = backslashSplits[backslashSplits.size() - 1];
 
-						std::string finalPath = selectedProject;
+						std::string finalPath = String::Split(selectedProject, '.')[0];
 
 						if (String::EndsWith(fileName, ".project"))
 						{
 							// We need to create a folder
-							if (const auto& dirPath = selectedProject;
-								std::filesystem::create_directory(dirPath))
+							if (const auto& dirPath = finalPath;
+								!std::filesystem::create_directory(dirPath))
 							{
 								// Should we continue?
 								Logger::Log("Failed creating project directory: " + dirPath);
 							}
 
-							finalPath += "\\" + fileName + ".project";
+							finalPath += "\\" + fileName;
 						}
 
-						auto project = Project::New(fileName, "no description", finalPath);
+						auto project = Project::New(String::Split(fileName, '.')[0], "no description", finalPath);
 						Engine::LoadProject(project);
 						Engine::LoadScene(Scene::New());
 						project->Save();

--- a/Nuake/src/Resource/Project.cpp
+++ b/Nuake/src/Resource/Project.cpp
@@ -53,6 +53,12 @@ namespace Nuake
 		projectFile.close();
 	}
 
+	bool Project::Exist()
+	{
+		struct stat buffer{};   
+		return (stat (this->FullPath.c_str(), &buffer) == 0);
+	}
+
 	Ref<Project> Project::New(const std::string& Name, const std::string& Description, const std::string& FullPath)
 	{
 		return CreateRef<Project>(Name, Description, FullPath);

--- a/Nuake/src/Resource/Project.cpp
+++ b/Nuake/src/Resource/Project.cpp
@@ -55,8 +55,7 @@ namespace Nuake
 
 	bool Project::FileExist()
 	{
-		struct stat buffer{};   
-		return (stat (this->FullPath.c_str(), &buffer) == 0);
+		return std::filesystem::exists(this->FullPath.c_str());
 	}
 
 	Ref<Project> Project::New(const std::string& Name, const std::string& Description, const std::string& FullPath)

--- a/Nuake/src/Resource/Project.cpp
+++ b/Nuake/src/Resource/Project.cpp
@@ -53,7 +53,7 @@ namespace Nuake
 		projectFile.close();
 	}
 
-	bool Project::Exist()
+	bool Project::FileExist()
 	{
 		struct stat buffer{};   
 		return (stat (this->FullPath.c_str(), &buffer) == 0);

--- a/Nuake/src/Resource/Project.h
+++ b/Nuake/src/Resource/Project.h
@@ -26,7 +26,7 @@ namespace Nuake
 
 		void Save();
 		void SaveAs(const std::string& FullPath);
-		bool Exist();
+		bool FileExist();
 
 		static Ref<Project> New(const std::string& Name, const std::string& Description, const std::string& FullPath);
 		static Ref<Project> New();

--- a/Nuake/src/Resource/Project.h
+++ b/Nuake/src/Resource/Project.h
@@ -26,6 +26,7 @@ namespace Nuake
 
 		void Save();
 		void SaveAs(const std::string& FullPath);
+		bool Exist();
 
 		static Ref<Project> New(const std::string& Name, const std::string& Description, const std::string& FullPath);
 		static Ref<Project> New();


### PR DESCRIPTION
## Changes
### On Welcome Window
- Now check if the user added `.project` at the end. If so, it doesn't add another `.project` at the end.
- Directory creation now works. 
- Change how the file is created to not include the suffix `.project`.
- Inverted file created condition. It was creating an error log when the file was successfully created. 

### On 'New Project' inside the editor
- Also check if the user added `.project` at the end. If so, it doesn't add another `.project` at the end.
- If the current `.project` file was deleted before creating a new project, it doesn't try to `Save()` it anymore.
- Now use `.empty()` for the string condition. It is safer and more accurate.

### Nuake
- Added a `FileExist()` method that checks if there is already a file at that path or not.