### PR TITLE
Creating New Project Editor does not create directory

### DIFF
--- a/Editor/src/Windows/EditorInterface.cpp
+++ b/Editor/src/Windows/EditorInterface.cpp
@@ -1277,6 +1277,8 @@ namespace Nuake {
         Ref<Project> project = Project::New(String::Split(fileName, '.')[0], "no description", finalPath);
         Engine::LoadProject(project);
         Engine::LoadScene(Scene::New());
+
+        Engine::GetCurrentWindow()->SetTitle("Nuake Engine - Editing " + project->Name); 
     }
 
 

--- a/Editor/src/Windows/EditorInterface.cpp
+++ b/Editor/src/Windows/EditorInterface.cpp
@@ -1258,8 +1258,23 @@ namespace Nuake {
         
         if (selectedProject.empty()) // Hit cancel
             return;
+
+        auto backslashSplits = String::Split(selectedProject, '\\');
+        auto fileName = backslashSplits[backslashSplits.size() - 1];
+
+        std::string finalPath = String::Split(selectedProject, '.')[0];
         
-        Ref<Project> project = Project::New("Unnamed project", "no description", selectedProject);
+        // We need to create a folder
+        if (const auto& dirPath = finalPath;
+            !std::filesystem::create_directory(dirPath))
+        {
+            // Should we continue?
+            Logger::Log("Failed creating project directory: " + dirPath);
+        }
+
+        finalPath += "\\" + fileName;
+        
+        Ref<Project> project = Project::New(String::Split(fileName, '.')[0], "no description", finalPath);
         Engine::LoadProject(project);
         Engine::LoadScene(Scene::New());
     }


### PR DESCRIPTION
## Changes
- Now create a directory when creating a new project
- Project name now use the directory name
- Now refresh the Window title (See Gif below)

## Refresh Window Title
![rider64_AcOFHZrlxF](https://github.com/antopilo/Nuake/assets/38258431/70f8bff4-7d56-404e-abe7-5b5e97696bcb)
