### PR TITLE
Delete Hovered File from Context Menu

### DIFF
--- a/Editor/src/Windows/FileSystemUI.cpp
+++ b/Editor/src/Windows/FileSystemUI.cpp
@@ -40,7 +40,8 @@ class MyEntityScript is ScriptableEntity {
 
 #include <src/Rendering/Textures/Material.h>
 
-namespace Nuake {
+namespace Nuake
+{
     
     // TODO: add filetree in same panel
     void FileSystemUI::Draw()
@@ -170,11 +171,12 @@ namespace Nuake {
             ImGui::OpenPopup(hoverMenuId.c_str());
             m_hasClickedOnFile = true;
         }
+        
         if (ImGui::BeginPopup(hoverMenuId.c_str()))
         {
             if (ImGui::MenuItem("Delete"))
             {
-                if(FileSystem::RemoveFile(file->GetAbsolutePath().c_str()) != 0)
+                if(FileSystem::RemoveFile(file->GetAbsolutePath()) != 0)
                 {
                     Logger::Log("Failed to remove file: " + file->GetAbsolutePath(), CRITICAL);
                 }
@@ -202,7 +204,10 @@ namespace Nuake {
     void FileSystemUI::DrawContextMenu()
     {
         if (!m_hasClickedOnFile && ImGui::IsMouseReleased(1) && ImGui::IsWindowHovered())
+        {
             ImGui::OpenPopup("window_hover_menu");
+        }
+        
         if (ImGui::BeginPopup("window_hover_menu"))
 		{
 			if (ImGui::MenuItem("New folder"))
@@ -401,6 +406,7 @@ namespace Nuake {
 
                         DrawContextMenu();
                         m_hasClickedOnFile = false;
+                        
                         ImGui::EndTable();
                     }
 

--- a/Editor/src/Windows/FileSystemUI.h
+++ b/Editor/src/Windows/FileSystemUI.h
@@ -11,9 +11,12 @@ namespace Nuake {
 
 	public:
 		Ref<Directory> m_CurrentDirectory;
+		bool m_hasClickedOnFile;
 
-		FileSystemUI(EditorInterface* editor) {
+		FileSystemUI(EditorInterface* editor)
+		{
 			m_CurrentDirectory = FileSystem::RootDirectory;
+			m_hasClickedOnFile = false;
 			Editor = editor;
 		}
 
@@ -23,8 +26,9 @@ namespace Nuake {
 		void EditorInterfaceDrawFiletree(Ref<Directory> dir);
 		void DrawDirectory(Ref<Directory> directory);
 		bool EntityContainsItself(Entity source, Entity target);
-		void DrawFile(Ref<File> file);
+		void DrawFile(Ref<File> file, uint32_t drawId);
 		void DrawDirectoryExplorer();
+		bool DeletePopup();
 		void DrawContextMenu();
 		void RefreshFileBrowser();
 	};

--- a/Nuake/src/Core/FileSystem.cpp
+++ b/Nuake/src/Core/FileSystem.cpp
@@ -166,6 +166,11 @@ namespace Nuake
 		fileWriter.close();
 	}
 
+	int FileSystem::RemoveFile(char const* path)
+	{
+		return std::remove(path);
+	}
+
 	Ref<Directory> FileSystem::GetFileTree()
 	{
 		return RootDirectory;

--- a/Nuake/src/Core/FileSystem.cpp
+++ b/Nuake/src/Core/FileSystem.cpp
@@ -166,9 +166,9 @@ namespace Nuake
 		fileWriter.close();
 	}
 
-	int FileSystem::RemoveFile(char const* path)
+	int FileSystem::RemoveFile(const std::string& path)
 	{
-		return std::remove(path);
+		return std::remove(path.c_str());
 	}
 
 	Ref<Directory> FileSystem::GetFileTree()

--- a/Nuake/src/Core/FileSystem.h
+++ b/Nuake/src/Core/FileSystem.h
@@ -43,7 +43,7 @@ namespace Nuake
 		static bool BeginWriteFile(const std::string path);
 		static bool WriteLine(const std::string line);
 		static void EndWriteFile();
-		static int RemoveFile(char const* path);
+		static int RemoveFile(const std::string& path);
 	};
 
 	class File

--- a/Nuake/src/Core/FileSystem.h
+++ b/Nuake/src/Core/FileSystem.h
@@ -43,6 +43,7 @@ namespace Nuake
 		static bool BeginWriteFile(const std::string path);
 		static bool WriteLine(const std::string line);
 		static void EndWriteFile();
+		static int RemoveFile(char const* path);
 	};
 
 	class File


### PR DESCRIPTION
## Changes
- Added Delete option on context menu. It is different from the one when no file is hovered.
- Delete the hovered file
![Editor_r9xAYBRbmo](https://github.com/antopilo/Nuake/assets/38258431/ca3c79f4-fcbd-42b7-83a4-7e47cd9d6f0e)

**Note**: A confirmation popup will be made [on another task](https://nuake.atlassian.net/browse/NK-100).