### PR TITLE
NK-86 - Use File Name as Class Name Wren Script

### DIFF
--- a/Editor/src/Windows/FileSystemUI.cpp
+++ b/Editor/src/Windows/FileSystemUI.cpp
@@ -262,7 +262,7 @@ namespace Nuake
 			            if(!String::IsDigit(fileName[0]))
 			            {
 			                
-			                FileSystem::BeginWriteFile(path);
+                            FileSystem::BeginWriteFile(path);
                             FileSystem::WriteLine(TEMPLATE_SCRIPT_FIRST + fileName + TEMPLATE_SCRIPT_SECOND);
                             FileSystem::EndWriteFile();
 			            

--- a/Editor/src/Windows/FileSystemUI.cpp
+++ b/Editor/src/Windows/FileSystemUI.cpp
@@ -9,13 +9,15 @@
 #include "src/Rendering/Textures/TextureManager.h"
 #include "EditorInterface.h"
 
-const std::string TEMPLATE_SCRIPT = R"(import "Nuake:Engine" for Engine 
+const std::string TEMPLATE_SCRIPT_FIRST = R"(import "Nuake:Engine" for Engine 
 import "Nuake:ScriptableEntity" for ScriptableEntity 
 import "Nuake:Input" for Input 
 import "Nuake:Math" for Vector3, Math 
 import "Nuake:Scene" for Scene 
 
-class MyEntityScript is ScriptableEntity { 
+class )";
+
+const std::string TEMPLATE_SCRIPT_SECOND = R"( is ScriptableEntity { 
         construct new() { 
         } 
 
@@ -246,6 +248,7 @@ namespace Nuake
 			    if (ImGui::MenuItem("Wren Script"))
 			    {
 			        std::string path = FileDialog::SaveFile("*.wren");
+			        
 			        if (!String::EndsWith(path, ".wren"))
 			        {
 			            path += ".wren";
@@ -253,11 +256,22 @@ namespace Nuake
 
 			        if (!path.empty())
 			        {
-			            FileSystem::BeginWriteFile(path);
-			            FileSystem::WriteLine(TEMPLATE_SCRIPT);
-			            FileSystem::EndWriteFile();
+                        std::string fileName = String::ToUpper(FileSystem::GetFileNameFromPath(path));
+			            fileName = String::RemoveWhiteSpace(fileName);
 			            
-			            RefreshFileBrowser();
+			            if(!String::IsDigit(fileName[0]))
+			            {
+			                
+			                FileSystem::BeginWriteFile(path);
+                            FileSystem::WriteLine(TEMPLATE_SCRIPT_FIRST + fileName + TEMPLATE_SCRIPT_SECOND);
+                            FileSystem::EndWriteFile();
+			            
+                            RefreshFileBrowser();
+                        }
+			            else
+			            {
+			                Logger::Log("[FileSystem] Cannot create script files that starts with a number.", CRITICAL);
+			            }
 			        }
 			    }
 

--- a/Nuake/src/Core/FileSystem.cpp
+++ b/Nuake/src/Core/FileSystem.cpp
@@ -210,4 +210,11 @@ namespace Nuake
 
 		return nullptr;
 	}
+
+	std::string FileSystem::GetFileNameFromPath(const std::string& path)
+	{
+		const auto split = String::Split(path, '\\');
+		return String::Split(split[split.size() - 1], '.')[0];
+	}
+	
 }

--- a/Nuake/src/Core/FileSystem.h
+++ b/Nuake/src/Core/FileSystem.h
@@ -31,6 +31,7 @@ namespace Nuake
 		static std::string AbsoluteToRelative(const std::string& path);
 		static Ref<Directory> GetFileTree();
 		static Ref<File> GetFile(const std::string& path);
+		static std::string GetFileNameFromPath(const std::string& path);
 		static void ScanDirectory(Ref<Directory> directory);
 		static void GetDirectories();
 

--- a/Nuake/src/Core/String.cpp
+++ b/Nuake/src/Core/String.cpp
@@ -19,6 +19,18 @@ namespace Nuake {
 			return false;
 	}
 
+	bool String::IsDigit(const char& character)
+	{
+		return character <= 57 && character >= 48;
+	}
+
+	std::string String::RemoveWhiteSpace(const std::string& string)
+	{
+		std::string result = string;
+		result.erase(remove_if(result.begin(), result.end(), isspace), result.end());
+		return result;
+	}
+
 	std::vector<std::string> String::Split(const std::string& string, char delimiter)
 	{
 		std::vector<std::string> result;
@@ -36,5 +48,23 @@ namespace Nuake {
 	float String::ToFloat(const std::string& string)
 	{
 		return std::stof(string);
+	}
+
+	std::string String::ToUpper(const std::string& string)
+	{
+		if(string.length() == 0)
+		{
+			return "";
+		}
+
+		auto split = Split(string, ' ');
+		std::string result;
+		for (auto& word : split)
+		{
+			word[0] = std::toupper(word[0]);
+			result += word;
+		}
+
+		return result;
 	}
 }

--- a/Nuake/src/Core/String.h
+++ b/Nuake/src/Core/String.h
@@ -11,8 +11,11 @@ namespace Nuake {
 	public:
 		static bool BeginsWith(const std::string& string, const std::string& begin);
 		static bool EndsWith(const std::string& string, const std::string& end);
+		static bool IsDigit(const char& character);
+		static std::string RemoveWhiteSpace(const std::string& string);
 		static std::vector<std::string> Split(const std::string& string, char delimiter);
 
 		static float ToFloat(const std::string& string);
+		static std::string ToUpper(const std::string& string);
 	};
 }


### PR DESCRIPTION
## Changes
- Now use the file name as a class name for the wren script
- Added methods on String class; `IsDigit(...)`, `RemoveWhiteSpace(...)` and `ToUpper(...)`
- Added method on FileSystem class: `GetFileNameFromPath(...)`