### PR TITLE
NK-99 - Show Folder in File Explorer

### DIFF
--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -92,7 +92,7 @@ int main(int argc, char* argv[])
         editor.BuildFonts();
 
         Ref<Nuake::Project> project = Nuake::Project::New();
-        FileSystem::SetRootDirectory(projectPath + "/../");
+        FileSystem::SetRootDirectory(FileSystem::RemoveFileFromPath(projectPath));
 
         project->FullPath = projectPath;
         project->Deserialize(FileSystem::ReadFile(projectPath, true));
@@ -143,7 +143,7 @@ int main(int argc, char* argv[])
 
         if (shouldLoadProject)
         {
-			FileSystem::SetRootDirectory(projectPath + "/../");
+			FileSystem::SetRootDirectory(FileSystem::RemoveFileFromPath(projectPath));
 
 			auto project = Project::New();
 			auto projectFileData = FileSystem::ReadFile(projectPath, true);

--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -92,7 +92,7 @@ int main(int argc, char* argv[])
         editor.BuildFonts();
 
         Ref<Nuake::Project> project = Nuake::Project::New();
-        FileSystem::SetRootDirectory(FileSystem::RemoveFileFromPath(projectPath));
+        FileSystem::SetRootDirectory(FileSystem::GetParentPath(projectPath));
 
         project->FullPath = projectPath;
         project->Deserialize(FileSystem::ReadFile(projectPath, true));
@@ -143,7 +143,7 @@ int main(int argc, char* argv[])
 
         if (shouldLoadProject)
         {
-			FileSystem::SetRootDirectory(FileSystem::RemoveFileFromPath(projectPath));
+			FileSystem::SetRootDirectory(FileSystem::GetParentPath(projectPath));
 
 			auto project = Project::New();
 			auto projectFileData = FileSystem::ReadFile(projectPath, true);

--- a/Editor/src/NewEditor.cpp
+++ b/Editor/src/NewEditor.cpp
@@ -41,7 +41,7 @@ namespace Nuake
 		{
 			// Parse the project and load it.
 			std::string projectPath = FileDialog::OpenFile(".project");
-			FileSystem::SetRootDirectory(FileSystem::RemoveFileFromPath(projectPath));
+			FileSystem::SetRootDirectory(FileSystem::GetParentPath(projectPath));
 			Ref<Project> project = Project::New();
 			if (!project->Deserialize(FileSystem::ReadFile(projectPath, true)))
 			{

--- a/Editor/src/NewEditor.cpp
+++ b/Editor/src/NewEditor.cpp
@@ -41,8 +41,7 @@ namespace Nuake
 		{
 			// Parse the project and load it.
 			std::string projectPath = FileDialog::OpenFile(".project");
-
-			FileSystem::SetRootDirectory(projectPath + "/../");
+			FileSystem::SetRootDirectory(FileSystem::RemoveFileFromPath(projectPath));
 			Ref<Project> project = Project::New();
 			if (!project->Deserialize(FileSystem::ReadFile(projectPath, true)))
 			{

--- a/Editor/src/Windows/EditorInterface.cpp
+++ b/Editor/src/Windows/EditorInterface.cpp
@@ -1291,7 +1291,7 @@ namespace Nuake {
         if (projectPath == "") // Hit cancel.
             return;
 
-        FileSystem::SetRootDirectory(projectPath + "/../");
+        FileSystem::SetRootDirectory(FileSystem::RemoveFileFromPath(projectPath));
         Ref<Project> project = Project::New();
         if (!project->Deserialize(FileSystem::ReadFile(projectPath, true)))
         {

--- a/Editor/src/Windows/EditorInterface.cpp
+++ b/Editor/src/Windows/EditorInterface.cpp
@@ -1291,7 +1291,7 @@ namespace Nuake {
         if (projectPath == "") // Hit cancel.
             return;
 
-        FileSystem::SetRootDirectory(FileSystem::RemoveFileFromPath(projectPath));
+        FileSystem::SetRootDirectory(FileSystem::GetParentPath(projectPath));
         Ref<Project> project = Project::New();
         if (!project->Deserialize(FileSystem::ReadFile(projectPath, true)))
         {

--- a/Editor/src/Windows/FileSystemUI.cpp
+++ b/Editor/src/Windows/FileSystemUI.cpp
@@ -178,7 +178,7 @@ namespace Nuake
         {
             if (ImGui::MenuItem("Show in File Explorer"))
             {
-                OS::OpenInFileExplorer(file->GetAbsolutePath());
+                OS::ShowInFileExplorer(file->GetAbsolutePath());
             }
             
             ImGui::Separator();

--- a/Editor/src/Windows/FileSystemUI.cpp
+++ b/Editor/src/Windows/FileSystemUI.cpp
@@ -176,15 +176,23 @@ namespace Nuake
         
         if (ImGui::BeginPopup(hoverMenuId.c_str()))
         {
+            if (ImGui::MenuItem("Show in File Explorer"))
+            {
+                OS::OpenInFileExplorer(file->GetAbsolutePath());
+            }
+            
+            ImGui::Separator();
+            
             if (ImGui::MenuItem("Delete"))
             {
                 if(FileSystem::RemoveFile(file->GetAbsolutePath()) != 0)
                 {
-                    Logger::Log("Failed to remove file: " + file->GetAbsolutePath(), CRITICAL);
+                    Logger::Log("Failed to remove file: " + file->GetRelativePath(), CRITICAL);
                 }
+                RefreshFileBrowser();
             }
+            
             ImGui::EndPopup();
-            RefreshFileBrowser();
         }
 
         ImGui::Text(file->GetName().c_str());

--- a/Editor/src/Windows/WelcomeWindow.cpp
+++ b/Editor/src/Windows/WelcomeWindow.cpp
@@ -254,7 +254,7 @@ namespace Nuake
 					SaveRecentFile();
 
 					std::string projectPath = _Projects[SelectedProject].Path;
-					FileSystem::SetRootDirectory(projectPath + "/../");
+					FileSystem::SetRootDirectory(FileSystem::RemoveFileFromPath(projectPath));
 
 					auto project = Project::New();
 					auto projectFileData = FileSystem::ReadFile(projectPath, true);

--- a/Editor/src/Windows/WelcomeWindow.cpp
+++ b/Editor/src/Windows/WelcomeWindow.cpp
@@ -254,7 +254,7 @@ namespace Nuake
 					SaveRecentFile();
 
 					std::string projectPath = _Projects[SelectedProject].Path;
-					FileSystem::SetRootDirectory(FileSystem::RemoveFileFromPath(projectPath));
+					FileSystem::SetRootDirectory(FileSystem::GetParentPath(projectPath));
 
 					auto project = Project::New();
 					auto projectFileData = FileSystem::ReadFile(projectPath, true);

--- a/Nuake/Engine.cpp
+++ b/Nuake/Engine.cpp
@@ -163,7 +163,7 @@ namespace Nuake
 			return false;
 		}
 
-		FileSystem::SetRootDirectory(project->FullPath + "/../");
+		FileSystem::SetRootDirectory(FileSystem::RemoveFileFromPath(project->FullPath));
 		return true;
 	}
 

--- a/Nuake/Engine.cpp
+++ b/Nuake/Engine.cpp
@@ -163,7 +163,7 @@ namespace Nuake
 			return false;
 		}
 
-		FileSystem::SetRootDirectory(FileSystem::RemoveFileFromPath(project->FullPath));
+		FileSystem::SetRootDirectory(FileSystem::GetParentPath(project->FullPath));
 		return true;
 	}
 

--- a/Nuake/src/Core/FileSystem.cpp
+++ b/Nuake/src/Core/FileSystem.cpp
@@ -124,7 +124,7 @@ namespace Nuake
 		return fs::relative(absolutePath, rootPath).generic_string();
 	}
 
-	std::string FileSystem::RemoveFileFromPath(const std::string& fullPath)
+	std::string FileSystem::GetParentPath(const std::string& fullPath)
 	{
 		std::filesystem::path pathObj(fullPath);
 		return pathObj.parent_path().string();

--- a/Nuake/src/Core/FileSystem.cpp
+++ b/Nuake/src/Core/FileSystem.cpp
@@ -124,6 +124,12 @@ namespace Nuake
 		return fs::relative(absolutePath, rootPath).generic_string();
 	}
 
+	std::string FileSystem::RemoveFileFromPath(const std::string& fullPath)
+	{
+		std::filesystem::path pathObj(fullPath);
+		return pathObj.parent_path().string();
+	}
+
 	std::string FileSystem::ReadFile(const std::string& path, bool absolute)
 	{
 		std::string finalPath = path;

--- a/Nuake/src/Core/FileSystem.h
+++ b/Nuake/src/Core/FileSystem.h
@@ -30,6 +30,7 @@ namespace Nuake
 
 		static void Scan();
 		static std::string AbsoluteToRelative(const std::string& path);
+		static std::string RemoveFileFromPath(const std::string& fullPath);
 		static Ref<Directory> GetFileTree();
 		static Ref<File> GetFile(const std::string& path);
 		static std::string GetFileNameFromPath(const std::string& path);

--- a/Nuake/src/Core/FileSystem.h
+++ b/Nuake/src/Core/FileSystem.h
@@ -30,7 +30,7 @@ namespace Nuake
 
 		static void Scan();
 		static std::string AbsoluteToRelative(const std::string& path);
-		static std::string RemoveFileFromPath(const std::string& fullPath);
+		static std::string GetParentPath(const std::string& fullPath);
 		static Ref<Directory> GetFileTree();
 		static Ref<File> GetFile(const std::string& path);
 		static std::string GetFileNameFromPath(const std::string& path);

--- a/Nuake/src/Core/OS.cpp
+++ b/Nuake/src/Core/OS.cpp
@@ -1,7 +1,6 @@
 ﻿#include "OS.h"
 
 #include <chrono>
-#include "String.h"
 #include <Windows.h>
 
 using namespace Nuake;
@@ -11,7 +10,7 @@ int OS::GetTime()
 	return static_cast<int>(std::chrono::system_clock::now().time_since_epoch().count());
 }
 
-void OS::OpenInFileExplorer(const std::string& filePath)
+void OS::ShowInFileExplorer(const std::string& filePath)
 {
 	ShellExecuteA(nullptr, "open", "explorer.exe", ("/select," + std::string(filePath)).c_str(), nullptr, SW_SHOWDEFAULT);
 }

--- a/Nuake/src/Core/OS.cpp
+++ b/Nuake/src/Core/OS.cpp
@@ -1,0 +1,17 @@
+﻿#include "OS.h"
+
+#include <chrono>
+#include "String.h"
+#include <Windows.h>
+
+using namespace Nuake;
+
+int OS::GetTime() 
+{
+	return static_cast<int>(std::chrono::system_clock::now().time_since_epoch().count());
+}
+
+void OS::OpenInFileExplorer(const std::string& filePath)
+{
+	ShellExecuteA(nullptr, "open", "explorer.exe", ("/select," + std::string(filePath)).c_str(), nullptr, SW_SHOWDEFAULT);
+}

--- a/Nuake/src/Core/OS.h
+++ b/Nuake/src/Core/OS.h
@@ -1,13 +1,14 @@
-#pragma once
+﻿#pragma once
+
+#include <string>
+
 
 namespace Nuake
 {
 	class OS 
 	{
 	public:
-		static int GetTime() 
-		{
-			return static_cast<int>(std::chrono::system_clock::now().time_since_epoch().count());
-		}
+		static int GetTime();
+		static void OpenInFileExplorer(const std::string& filePath);
 	};
 }

--- a/Nuake/src/Core/OS.h
+++ b/Nuake/src/Core/OS.h
@@ -2,13 +2,12 @@
 
 #include <string>
 
-
 namespace Nuake
 {
 	class OS 
 	{
 	public:
 		static int GetTime();
-		static void OpenInFileExplorer(const std::string& filePath);
+		static void ShowInFileExplorer(const std::string& filePath);
 	};
 }


### PR DESCRIPTION
## Changes
- `Show in File Explorer` option added to the context menu while hovering a file. 
- Once open, it automatically selects the file.
- Removed `*.project/../` from the RootDirectory. Now includes the path to the file directly.
   (e.g. `/test/my-project.project/../my-script.wren` ➡️ `/test/my-script.wren`)