### PR TITLE
NK-78 - Display wren script in properties

### DIFF
--- a/Editor/src/Windows/EditorSelectionPanel.cpp
+++ b/Editor/src/Windows/EditorSelectionPanel.cpp
@@ -5,6 +5,7 @@
 #include <src/Rendering/Textures/Material.h>
 #include <src/Resource/ResourceLoader.h>
 #include <src/Resource/FontAwesome5.h>
+#include <src/Scripting/WrenScript.h>
 #include <Engine.h>
 
 EditorSelectionPanel::EditorSelectionPanel()
@@ -60,7 +61,7 @@ void EditorSelectionPanel::Draw(EditorSelection selection)
                     ResolveFile(selection.File);
                 }
 
-                DrawFile(selection.File.get());
+                DrawFile(selection.File);
                 break;
             }
             case EditorSelectionType::Resource:
@@ -140,7 +141,7 @@ void EditorSelectionPanel::DrawAddComponentMenu(Nuake::Entity entity)
 }
 
 
-void EditorSelectionPanel::DrawFile(Nuake::File* file)
+void EditorSelectionPanel::DrawFile(Ref<Nuake::File> file)
 {
     using namespace Nuake;
     if (file->GetExtension() == ".material")
@@ -151,6 +152,10 @@ void EditorSelectionPanel::DrawFile(Nuake::File* file)
     {
         DrawProjectPanel(Nuake::Engine::GetProject());
     }
+	if (file->GetExtension() == ".wren")
+	{
+		DrawWrenScriptPanel(CreateRef<WrenScript>(file, true));
+	}
 }
 
 void EditorSelectionPanel::DrawResource(Nuake::Resource resource)
@@ -413,5 +418,18 @@ void EditorSelectionPanel::DrawProjectPanel(Ref<Nuake::Project> project)
     }
     ImGui::SameLine();
     ImGui::InputText("Trenchbroom Path", &project->TrenchbroomPath);
+}
+
+void EditorSelectionPanel::DrawWrenScriptPanel(Ref<Nuake::WrenScript> wrenFile)
+{
+	auto filePath = wrenFile->GetFile()->GetAbsolutePath();
+	std::string fileContent = Nuake::FileSystem::ReadFile(filePath, true);
+
+	ImGui::Text("Content");
+	ImGui::Separator();
+	ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + ImGui::GetWindowWidth());
+	ImGui::Text(fileContent.c_str(), ImGui::GetWindowWidth());
+	
+	ImGui::PopTextWrapPos();
 }
 

--- a/Editor/src/Windows/EditorSelectionPanel.h
+++ b/Editor/src/Windows/EditorSelectionPanel.h
@@ -46,11 +46,12 @@ public:
 	void DrawEntity(Nuake::Entity entity);
 	void DrawAddComponentMenu(Nuake::Entity entity);
 
-	void DrawFile(Nuake::File* file);
+	void DrawFile(Ref<Nuake::File> file);
 	void DrawResource(Nuake::Resource resource);
 
 private:
 	void ResolveFile(Ref<Nuake::File> file);
 	void DrawMaterialPanel(Ref<Nuake::Material> material);
 	void DrawProjectPanel(Ref<Nuake::Project> project);
+	void DrawWrenScriptPanel(Ref<Nuake::WrenScript> wrenFile);
 };

--- a/Nuake/src/Scripting/WrenScript.cpp
+++ b/Nuake/src/Scripting/WrenScript.cpp
@@ -164,6 +164,11 @@ namespace Nuake
 		WrenInterpretResult result = wrenCall(vm, handle);
 	}
 
+	Ref<File> WrenScript::GetFile() const
+	{
+		return mFile;
+	}
+
 	void WrenScript::SetScriptableEntityID(int id)
 	{
 		if (!m_HasCompiledSuccesfully)

--- a/Nuake/src/Scripting/WrenScript.h
+++ b/Nuake/src/Scripting/WrenScript.h
@@ -40,6 +40,7 @@ namespace Nuake
 
 		void RegisterMethod(const std::string& signature);
 		void CallMethod(const std::string& signature);
+		Ref<File> GetFile() const;
 
 		void SetScriptableEntityID(int id);
 		bool HasCompiledSuccesfully() const { return m_HasCompiledSuccesfully; }


### PR DESCRIPTION
## Changes
- Now display a read-only 'Content' of Wren Script file.
![Editor_RLTJQ1OEJz](https://github.com/antopilo/Nuake/assets/38258431/1f131f7b-9a43-4468-9c2b-88f3860dee5c)
