### PR TITLE
NK-108 - Removed delete from .project context menu

### DIFF
--- a/Editor/src/Windows/FileSystemUI.cpp
+++ b/Editor/src/Windows/FileSystemUI.cpp
@@ -180,16 +180,19 @@ namespace Nuake
             {
                 OS::ShowInFileExplorer(file->GetAbsolutePath());
             }
-            
-            ImGui::Separator();
-            
-            if (ImGui::MenuItem("Delete"))
+
+            if(file->GetExtension() != ".project")
             {
-                if(FileSystem::RemoveFile(file->GetAbsolutePath()) != 0)
+                ImGui::Separator();
+            
+                if (ImGui::MenuItem("Delete"))
                 {
-                    Logger::Log("Failed to remove file: " + file->GetRelativePath(), CRITICAL);
+                    if(FileSystem::RemoveFile(file->GetAbsolutePath()) != 0)
+                    {
+                        Logger::Log("Failed to remove file: " + file->GetRelativePath(), CRITICAL);
+                    }
+                    RefreshFileBrowser();
                 }
-                RefreshFileBrowser();
             }
             
             ImGui::EndPopup();


### PR DESCRIPTION
## Changes
- Removed the option to 'Delete' from the context menu while hovering a .project file.
![Editor_LzPSyi4Urq](https://github.com/antopilo/Nuake/assets/38258431/289f4a4e-3a8c-474f-aa63-ad0c5b854789)
