### PR TITLE
NK-116 Add prefab scripting API

### DIFF
--- a/Editor/resources/Scripts/Scene.wren
+++ b/Editor/resources/Scripts/Scene.wren
@@ -4,7 +4,9 @@ import "Nuake:Math" for Vector3
 class Scene {
 	foreign static GetEntityID(name)
 
-
+	foreign static AddEntity(name)
+	foreign static AddPrefab(prefabPath)
+	
 	static GetEntity(name) {
 		var entId = Scene.GetEntityID(name)
 		var ent = Entity.new(entId)

--- a/Nuake/src/Core/FileSystem.cpp
+++ b/Nuake/src/Core/FileSystem.cpp
@@ -220,7 +220,7 @@ namespace Nuake
 
 	std::string FileSystem::GetFileNameFromPath(const std::string& path)
 	{
-		const auto split = String::Split(path, '\\');
+		const auto& split = String::Split(path, '\\');
 		return String::Split(split[split.size() - 1], '.')[0];
 	}
 	

--- a/Nuake/src/Scene/Scene.cpp
+++ b/Nuake/src/Scene/Scene.cpp
@@ -179,12 +179,14 @@ namespace Nuake {
 	Entity Scene::GetEntity(const std::string& name)
 	{
 		std::vector<Entity> allEntities;
-		auto view = m_Registry.view<TransformComponent, NameComponent>();
+		const auto& view = m_Registry.view<NameComponent>();
 		for (auto e : view) 
 		{
-			auto [transform, namec] = view.get<TransformComponent, NameComponent>(e);
+			const auto& namec = view.get<NameComponent>(e);
 			if (namec.Name == name)
+			{
 				return Entity{ e, this };
+			}
 		}
 
 		return Entity();

--- a/Nuake/src/Scene/Scene.cpp
+++ b/Nuake/src/Scene/Scene.cpp
@@ -197,16 +197,50 @@ namespace Nuake {
 
 	Entity Scene::CreateEntity(const std::string& name, int id)
 	{
+		if (name.empty())
+		{
+			Logger::Log("[Scene] Failed to create entity. Entity name cannot be empty.");
+			return Entity();
+		}
+
+		std::string entityName;
+		if (GetEntity(name) != Entity())
+		{
+			entityName = name;
+		}
+		else
+		{
+			// Try to generate a unique name
+			for (uint32_t i = 1; i < 2048; i++)
+			{
+				const std::string& entityEnumName = name + std::to_string(i);
+				const auto& entityId = GetEntity(entityEnumName).GetHandle();
+				if (entityId != -1)
+				{
+					entityName = entityEnumName;
+					break;
+				}
+			}
+
+			if (entityName.empty()) // We ran out of names!!!
+			{
+				Logger::Log("[Scene] Failed to create entity. Limit reached with name: " + name, CRITICAL);
+				return Entity();
+			}
+		}
+
 		Entity entity = { m_Registry.create(), this };
+
+		// Add all mandatory component. An entity cannot exist without these.
 		entity.AddComponent<TransformComponent>();
 		entity.AddComponent<ParentComponent>();
 		entity.AddComponent<VisibilityComponent>();
 
 		NameComponent& nameComponent = entity.AddComponent<NameComponent>();
-		nameComponent.Name = name;
+		nameComponent.Name = entityName;
 		nameComponent.ID = id;
 
-		Logger::Log("Created entity: " + nameComponent.Name, LOG_TYPE::VERBOSE);
+		Logger::Log("[Scene] Entity created with name: " + nameComponent.Name, LOG_TYPE::VERBOSE);
 		return entity;
 	}
 

--- a/Nuake/src/Scripting/Modules/SceneModule.h
+++ b/Nuake/src/Scripting/Modules/SceneModule.h
@@ -107,7 +107,6 @@ namespace Nuake {
 				prefabComponent.PrefabInstance = Prefab::New(prefabPath);
 
 				wrenSetSlotDouble(vm, 0, newEntity.GetHandle());
-				return;
 			}
 
 			static void EntityHasComponent(WrenVM* vm)

--- a/Nuake/src/Scripting/ScriptingEngine.cpp
+++ b/Nuake/src/Scripting/ScriptingEngine.cpp
@@ -20,7 +20,6 @@ namespace Nuake {
         const char* module, const int line,
         const char* msg)
     {
-        Logger::Log("YO");
         switch (errorType)
         {
         case WREN_ERROR_COMPILE:


### PR DESCRIPTION
## Changes
- You can now instantiate prefabs from the scripting API at runtime.
- Also added entity name incrementing if an entity with the same name exists already.
- Also exposed CreateEntity to the scripting API.
- Cleaned up debug log

You can now do the following:
```lua
Scene.AddPrefab("path/to/prefab.prefab")
```

