### PR TITLE
NK-113 - Open Wren Script File with Double Click

### DIFF
--- a/Editor/src/ComponentsPanel/ScriptPanel.h
+++ b/Editor/src/ComponentsPanel/ScriptPanel.h
@@ -27,7 +27,7 @@ public:
                     if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("_Script"))
                     {
                         char* file = (char*)payload->Data;
-                        
+
                         std::string fullPath = std::string(file, 512);
                         path = Nuake::FileSystem::AbsoluteToRelative(std::move(fullPath));
 

--- a/Editor/src/ComponentsPanel/ScriptPanel.h
+++ b/Editor/src/ComponentsPanel/ScriptPanel.h
@@ -27,7 +27,7 @@ public:
                     if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("_Script"))
                     {
                         char* file = (char*)payload->Data;
-
+                        
                         std::string fullPath = std::string(file, 512);
                         path = Nuake::FileSystem::AbsoluteToRelative(std::move(fullPath));
 
@@ -37,6 +37,16 @@ public:
                 }
 
                 component.Script = path;
+
+                // Double click on file
+                if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(0))
+                {
+                    if(!component.Script.empty())
+                    {
+                        Nuake::OS::OpenIn(component.mWrenScript->GetFile()->GetAbsolutePath());
+                    }
+                }
+                
                 ImGui::TableNextColumn();
 
                 ComponentTableReset(component.Script, "");

--- a/Nuake/src/Scene/Components/WrenScriptComponent.h
+++ b/Nuake/src/Scene/Components/WrenScriptComponent.h
@@ -39,7 +39,10 @@ namespace Nuake
 			if (j.contains("Script"))
 			{
 				Script = j["Script"];
-				LoadScript(Script);
+				if(!Script.empty())
+				{
+					LoadScript(Script);
+				}
 			}
 
 			if (j.contains("mModule"))


### PR DESCRIPTION
## Changes
- Open Wren Script File with Double Click on component
- Fixed crashes occurring when opening a scene with an empty Script in WrenScriptComponent