### PR TITLE
NK-79 - Rename File & Folder

### DIFF
--- a/Editor/src/Misc/PopupHelper.cpp
+++ b/Editor/src/Misc/PopupHelper.cpp
@@ -45,7 +45,7 @@ bool PopupHelper::DefineTextDialog(const std::string& id, std::string& currentTe
         char buffer[256];
         memset(buffer, 0, sizeof(buffer));
         std::strncpy(buffer, currentText.c_str(), sizeof(buffer));
-        if (ImGui::InputText("", buffer, sizeof(buffer)))
+        if (ImGui::InputText("##label", buffer, sizeof(buffer)))
         {
             currentText = std::string(buffer);
         }


### PR DESCRIPTION
## Changes
- Added Hidden Label on InputText of `PopupHelper::DefineTextDialog(...)`. 
We can now rename Files and Folders 🥳

The lack of label was the reason why it was crashing.