### PR TITLE
Initial reflection for components using the entt reflection API

### DIFF
--- a/Editor/src/Windows/EditorSelectionPanel.cpp
+++ b/Editor/src/Windows/EditorSelectionPanel.cpp
@@ -13,6 +13,8 @@
 #include <Engine.h>
 #include <src/Resource/Prefab.h>
 
+#include <entt/entt.hpp>
+
 using namespace Nuake;
 
 EditorSelectionPanel::EditorSelectionPanel()
@@ -151,32 +153,19 @@ void EditorSelectionPanel::DrawEntity(Nuake::Entity entity)
 
 	if (ImGui::BeginPopup("ComponentPopup"))
 	{
-		MenuItemComponent("Wren Script", WrenScriptComponent);
-		MenuItemComponent("C# Script", NetScriptComponent);
-		MenuItemComponent("Camera", CameraComponent);
-		MenuItemComponent("Light", LightComponent);
-		ImGui::Separator();
-		MenuItemComponent("Model", ModelComponent);
-		MenuItemComponent("Skinned Model", SkinnedModelComponent);
-		MenuItemComponent("Bone", BoneComponent)
-			ImGui::Separator();
-		MenuItemComponent("Sprite", SpriteComponent)
-			MenuItemComponent("Particle Emitter", ParticleEmitterComponent)
-			ImGui::Separator();
-		MenuItemComponent("Character Controller", CharacterControllerComponent)
-			MenuItemComponent("Rigid body", RigidBodyComponent)
-			ImGui::Separator();
-		MenuItemComponent("Box collider", BoxColliderComponent)
-			MenuItemComponent("Capsule collider", CapsuleColliderComponent)
-			MenuItemComponent("Cylinder collider", CylinderColliderComponent)
-			MenuItemComponent("Sphere collider", SphereColliderComponent)
-			MenuItemComponent("Mesh collider", MeshColliderComponent)
-			ImGui::Separator();
-		MenuItemComponent("Quake map", QuakeMapComponent);
-		ImGui::Separator();
-		MenuItemComponent("Audio Emitter", AudioEmitterComponent);
-		ImGui::Separator();
-		MenuItemComponent("NavMesh Volume", NavMeshVolumeComponent);
+		for(entt::meta_type t : entt::resolve())
+		{
+			if (entt::meta_func func = t.func(HashedFnName::GetComponentName))
+			{
+				entt::meta_any ret = func.invoke(t);
+				std::string className = ret.cast<std::string>();
+				if (ImGui::MenuItem(className.c_str()))
+				{
+					entity.AddComponent(t);
+				}
+			}
+		}
+		
 		ImGui::EndPopup();
 	}
 

--- a/Nuake/src/Core/Object/Object.h
+++ b/Nuake/src/Core/Object/Object.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <entt/entt.hpp>
+
+#define NK_HASHED_FN_NAME_IMPL(name) inline static constexpr entt::hashed_string name = entt::hashed_string(#name);
+
+namespace Nuake
+{
+    struct HashedFnName
+    {
+        NK_HASHED_FN_NAME_IMPL(GetComponentName)
+        NK_HASHED_FN_NAME_IMPL(AddToEntity)
+    };
+}
+
+#define NUAKECOMPONENT(klass, componentName)                                      \
+public:                                                                           \
+    static std::string ClassName()                                                \
+    {                                                                             \
+        static std::string className = #klass;                                    \
+        return className;                                                         \
+    }                                                                             \
+                                                                                  \
+    static std::string ComponentName()                                            \
+    {                                                                             \
+        static std::string name = componentName;                                  \
+        return name;                                                              \
+    }                                                                             \
+                                                                                  \
+    static void AddToEntity(entt::entity entity, entt::registry* enttRegistry)    \
+    {                                                                             \
+        enttRegistry->emplace_or_replace<klass>(entity);                          \
+    }                                                                             \
+                                                                                  \
+    inline static auto ComponentFactory = entt::meta<klass>()                     \
+        .type(entt::hashed_string(#klass))                                        \
+        .func<&klass::ComponentName>(HashedFnName::GetComponentName)              \
+        .func<&klass::AddToEntity>(HashedFnName::AddToEntity);

--- a/Nuake/src/Scene/Components/AudioEmitterComponent.h
+++ b/Nuake/src/Scene/Components/AudioEmitterComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include "src/Core/Object/Object.h"
 #include "src/Core/Core.h"
 #include "src/Resource/Serializable.h"
 
@@ -6,6 +8,8 @@ namespace Nuake {
 
 	class AudioEmitterComponent
 	{
+		NUAKECOMPONENT(AudioEmitterComponent, "Audio Emitter")
+
 	public:
 		std::string FilePath;
 

--- a/Nuake/src/Scene/Components/BoneComponent.h
+++ b/Nuake/src/Scene/Components/BoneComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include "src/Core/Object/Object.h"
 #include "src/Core/Core.h"
 #include "src/Resource/Serializable.h"
 
@@ -7,6 +9,8 @@ namespace Nuake
 {
 	class BoneComponent
 	{
+        NUAKECOMPONENT(BoneComponent, "Bone")
+
 	public:
 		BoneComponent() = default;
 		~BoneComponent() = default;

--- a/Nuake/src/Scene/Components/BoxCollider.h
+++ b/Nuake/src/Scene/Components/BoxCollider.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include "src/Core/Object/Object.h"
 #include "src/Physics/PhysicsShapes.h"
 #include "src/Core/Core.h"
 
@@ -6,6 +8,8 @@ namespace Nuake {
 
 	class BoxColliderComponent
 	{
+		NUAKECOMPONENT(BoxColliderComponent, "Box Collider")
+
 	public:
 		Ref<Physics::PhysicShape> Box;
 		Vector3 Size = Vector3(0.5f, 0.5f, 0.5f);

--- a/Nuake/src/Scene/Components/CameraComponent.h
+++ b/Nuake/src/Scene/Components/CameraComponent.h
@@ -1,4 +1,7 @@
 #pragma once
+
+#include "src/Core/Object/Object.h"
+
 #include "TransformComponent.h"
 #include "src/Core/Core.h"
 #include "src/Resource/Serializable.h"
@@ -6,8 +9,11 @@
 
 namespace Nuake
 {
+	
 	class CameraComponent 
 	{
+		NUAKECOMPONENT(CameraComponent, "Camera")
+		
 	public:
 		Ref<Camera> CameraInstance;
 		TransformComponent* transformComponent;

--- a/Nuake/src/Scene/Components/CapsuleColliderComponent.h
+++ b/Nuake/src/Scene/Components/CapsuleColliderComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include "src/Core/Object/Object.h"
 #include "src/Physics/PhysicsShapes.h"
 #include "src/Core/Core.h"
 
@@ -6,6 +8,8 @@ namespace Nuake
 {
 	class CapsuleColliderComponent
 	{
+		NUAKECOMPONENT(CapsuleColliderComponent, "Capsule Collider")
+
 	public:
 		Ref<Physics::Capsule> Capsule;
 

--- a/Nuake/src/Scene/Components/CharacterControllerComponent.h
+++ b/Nuake/src/Scene/Components/CharacterControllerComponent.h
@@ -1,10 +1,14 @@
 #pragma once
+
+#include "src/Core/Object/Object.h"
 #include "src/Physics/CharacterController.h"
 
 namespace Nuake 
 {
 	class CharacterControllerComponent
 	{
+		NUAKECOMPONENT(CharacterControllerComponent, "Character Controller")
+
 	private:
 		Ref<Physics::CharacterController>  m_CharacterController;
 

--- a/Nuake/src/Scene/Components/CylinderColliderComponent.h
+++ b/Nuake/src/Scene/Components/CylinderColliderComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include "src/Core/Object/Object.h"
 #include "src/Physics/PhysicsShapes.h"
 #include "src/Core/Core.h"
 
@@ -6,6 +8,8 @@ namespace Nuake
 {
 	class CylinderColliderComponent
 	{
+		NUAKECOMPONENT(CylinderColliderComponent, "Cylinder Collider")
+
 	public:
 		Ref<Physics::Cylinder> Cylinder;
 

--- a/Nuake/src/Scene/Components/LightComponent.h
+++ b/Nuake/src/Scene/Components/LightComponent.h
@@ -1,4 +1,7 @@
 #pragma once
+
+#include "src/Core/Object/Object.h"
+
 #include <glm/ext/vector_float3.hpp>
 #include <glm/ext/vector_float2.hpp>
 #include "TransformComponent.h"
@@ -19,6 +22,8 @@ namespace Nuake
     const int CSM_AMOUNT = 4;
     class LightComponent 
     {
+        NUAKECOMPONENT(LightComponent, "Light")
+
     public:
         LightType Type = Point;
         Vector3 Direction;

--- a/Nuake/src/Scene/Components/MeshCollider.h
+++ b/Nuake/src/Scene/Components/MeshCollider.h
@@ -1,10 +1,14 @@
 #pragma once
+
+#include "src/Core/Object/Object.h"
 #include "src/Physics/PhysicsShapes.h"
 #include "src/Core/Core.h"
 
 namespace Nuake {
 	class MeshColliderComponent
 	{
+		NUAKECOMPONENT(MeshColliderComponent, "Mesh Collider")
+
 	public:
 		uint32_t SubMesh = 0;
 		bool IsTrigger;

--- a/Nuake/src/Scene/Components/ModelComponent.h
+++ b/Nuake/src/Scene/Components/ModelComponent.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "src/Core/Object/Object.h"
 #include "src/Core/String.h"
 #include "src/Resource/Model.h"
 #include "src/Resource/ResourceLoader.h"
@@ -13,6 +14,8 @@ namespace Nuake
 {
     struct ModelComponent
     {
+        NUAKECOMPONENT(ModelComponent, "Model")
+
         Ref<Model> ModelResource;
         std::string ModelPath;
 

--- a/Nuake/src/Scene/Components/NavMeshVolumeComponent.h
+++ b/Nuake/src/Scene/Components/NavMeshVolumeComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include "src/Core/Object/Object.h"
 #include "../Entities/Entity.h"
 #include "Engine.h"
 #include <src/AI/NavMesh.h>
@@ -7,6 +9,8 @@ namespace Nuake
 {
 	struct NavMeshVolumeComponent
 	{
+		NUAKECOMPONENT(NavMeshVolumeComponent, "Nav Mesh Volume")
+
 		Vector3 VolumeSize = { 1.0f, 1.0f, 1.0f };
 		bool OnlyIncludeMapGeometry = true;
 

--- a/Nuake/src/Scene/Components/NetScriptComponent.h
+++ b/Nuake/src/Scene/Components/NetScriptComponent.h
@@ -1,5 +1,6 @@
-
 #pragma once
+
+#include "src/Core/Object/Object.h"
 #include "src/Core/Core.h"
 #include "src/Core/Maths.h"
 #include "src/FileSystem/FileSystem.h"
@@ -7,6 +8,8 @@
 #include "src/Resource/Serializable.h"
 #include "src/Resource/File.h"
 #include <any>
+
+#include "src/Core/Object/Object.h"
 
 namespace Nuake {
 
@@ -33,6 +36,8 @@ namespace Nuake {
 
 	class NetScriptComponent
 	{
+		NUAKECOMPONENT(NetScriptComponent, "Net Script")
+		
 	public:
 		std::string ScriptPath;
 		std::string Class;

--- a/Nuake/src/Scene/Components/ParticleEmitterComponent.h
+++ b/Nuake/src/Scene/Components/ParticleEmitterComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include "src/Core/Object/Object.h"
 #include "src/Core/Core.h"
 #include "src/Core/Maths.h"
 #include "src/Resource/Serializable.h"
@@ -10,6 +12,8 @@ namespace Nuake
 {
 	class ParticleEmitterComponent
 	{
+		NUAKECOMPONENT(ParticleEmitterComponent, "Particle Emitter")
+
 	public:
 		ParticleEmitterComponent() = default;
 		~ParticleEmitterComponent() = default;

--- a/Nuake/src/Scene/Components/QuakeMap.h
+++ b/Nuake/src/Scene/Components/QuakeMap.h
@@ -2,6 +2,7 @@
 #include <string>
 #include <vector>
 
+#include "src/Core/Object/Object.h"
 #include "src/Rendering/Mesh/Mesh.h"
 #include "src/Resource/Serializable.h"
 #include "src/Scene/Systems/QuakeMapBuilder.h"
@@ -12,6 +13,8 @@ namespace Nuake {
 
 	class QuakeMapComponent
 	{
+		NUAKECOMPONENT(QuakeMapComponent, "Quake Map")
+
 	public:
 		std::vector<Ref<Mesh>> m_Meshes;
 		std::vector<Entity> m_Brushes;

--- a/Nuake/src/Scene/Components/RigidbodyComponent.h
+++ b/Nuake/src/Scene/Components/RigidbodyComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include "src/Core/Object/Object.h"
 #include "TransformComponent.h"
 #include "BaseComponent.h"
 #include "src/Core/Core.h"
@@ -11,6 +13,8 @@ namespace Nuake {
 
 	class RigidBodyComponent
 	{
+		NUAKECOMPONENT(RigidBodyComponent, "Rigid Body")
+
 	public:
 		float Mass;
 		bool LockX = false;

--- a/Nuake/src/Scene/Components/SkinnedModelComponent.h
+++ b/Nuake/src/Scene/Components/SkinnedModelComponent.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <vector>
 
+#include "src/Core/Object/Object.h"
 #include "src/Resource/Serializable.h"
 #include "src/Resource/SkinnedModel.h"
 
@@ -11,6 +12,8 @@ namespace Nuake
 {
     struct SkinnedModelComponent
     {
+        NUAKECOMPONENT(SkinnedModelComponent, "Skinned Model")
+
         Ref<SkinnedModel> ModelResource;
         std::string ModelPath;
 

--- a/Nuake/src/Scene/Components/SphereCollider.h
+++ b/Nuake/src/Scene/Components/SphereCollider.h
@@ -1,10 +1,14 @@
 #pragma once
+
+#include "src/Core/Object/Object.h"
 #include "src/Physics/PhysicsShapes.h"
 #include "src/Core/Core.h"
 
 namespace Nuake {
 	class SphereColliderComponent
 	{
+		NUAKECOMPONENT(SphereColliderComponent, "Sphere Component")
+
 	public:
 		Ref<Physics::PhysicShape> Sphere;
 

--- a/Nuake/src/Scene/Components/SpriteComponent.h
+++ b/Nuake/src/Scene/Components/SpriteComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include "src/Core/Object/Object.h"
 #include "src/Core/Core.h"
 #include "src/Resource/Serializable.h"
 #include "src/Rendering/Textures/Texture.h"
@@ -8,6 +10,8 @@ namespace Nuake
 {
 	class SpriteComponent
 	{
+		NUAKECOMPONENT(SpriteComponent, "Sprite")
+
 	public:
 		bool Billboard;
 		bool LockYRotation;

--- a/Nuake/src/Scene/Entities/Entity.h
+++ b/Nuake/src/Scene/Entities/Entity.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <string>
 #include <glm/ext/matrix_float4x4.hpp>
+
+#include "src/Core/Logger.h"
 #include "../Scene.h"
 #include "../Components/BaseComponent.h"
 #include "../Resource/Serializable.h"
@@ -29,6 +31,32 @@ namespace Nuake
 		bool IsValid() const
 		{
 			return m_EntityHandle != (entt::entity)-1 && m_Scene->m_Registry.valid((entt::entity)GetHandle());
+		}
+
+		void AddComponent(entt::meta_type& enttMetaType)
+		{
+			if (!enttMetaType)
+			{
+				Logger::Log("Meta data empty/invalid", "Entity", WARNING);
+				return;
+			}
+
+			entt::meta_any newComponent = enttMetaType.construct();
+			if (!newComponent)
+			{
+				Logger::Log("Could not create a component from the meta type", "Entity", CRITICAL);
+				return;
+			}
+
+			auto func = enttMetaType.func(HashedFnName::AddToEntity);
+			// TODO: [WiggleWizard] Needs a lot more validation
+			if (!func)
+			{
+				Logger::Log("No such function exists or is registered on component", "Entity", CRITICAL);
+				return;
+			}
+
+			func.invoke(newComponent, m_EntityHandle, &m_Scene->m_Registry);
 		}
 
 		template<typename T>


### PR DESCRIPTION
Currently the only system using reflection is the drop down box when clicking "Add Component" in the entity inspector. The other systems and architecture is still designed around concrete compile time typing