### PR TITLE
FIxed warnings for Premake5 [Issue #74]

### DIFF
--- a/Nuake/dependencies/recastnavigation_p5.lua
+++ b/Nuake/dependencies/recastnavigation_p5.lua
@@ -67,7 +67,6 @@ project "Detour"
 		defines {"DEBUG"}
 		symbols "On"
 		postbuildcommands {}
-		flags {"staticruntime"} -- this is what worked for me
 
 	-- linux library cflags and libs
 	filter {"system:linux", "toolset:gcc"}

--- a/premake5.lua
+++ b/premake5.lua
@@ -263,7 +263,7 @@ project "NuakeRuntime"
         kind "WindowedApp"
         runtime "Release"
         optimize "on"
-        flags { "WinMain" }
+        flags { "WinMainCRTStartup" }
         defines
         {
             "NK_DIST",

--- a/premake5.lua
+++ b/premake5.lua
@@ -263,7 +263,8 @@ project "NuakeRuntime"
         kind "WindowedApp"
         runtime "Release"
         optimize "on"
-        flags { "WinMainCRTStartup" }
+        entrypoint "WinMainCRTStartup"
+        flags { }
         defines
         {
             "NK_DIST",


### PR DESCRIPTION
Updated premake5.lua and Nuake/dependencies/recastenavigation_p5.lua per warnings in Issue #74