### PR TITLE
ICall delegates -> unmanged

### DIFF
--- a/EditorNet/src/Editor.cs
+++ b/EditorNet/src/Editor.cs
@@ -8,8 +8,8 @@ namespace Nuake
 {
     class Editor
     {
-        internal static unsafe delegate*<int, void> SetSelectedEntityIcall;
-        internal static unsafe delegate*<int> GetSelectedEntityIcall;
+        internal static unsafe delegate* unmanaged<int, void> SetSelectedEntityIcall;
+        internal static unsafe delegate* unmanaged<int> GetSelectedEntityIcall;
 
         static int STACK_CAPACITY = 32;
         private static Stack<ICommand> CommandStack = new(STACK_CAPACITY);

--- a/Nuake/src/Scripting/NetModules/SceneNetAPI.cpp
+++ b/Nuake/src/Scripting/NetModules/SceneNetAPI.cpp
@@ -54,11 +54,8 @@ namespace Nuake {
 		Entity entity = scene->GetEntity(entityName);
 
 		auto& scriptingEngine = ScriptingEngineNet::Get();
-		if (scriptingEngine.HasEntityScriptInstance(entity))
-		{
-			auto instance = scriptingEngine.GetEntityScript(entity);
-			outInstance->m_Handle = instance->m_Handle;
-			outInstance->m_Type = instance->m_Type;
+		if (auto instance = scriptingEngine.GetEntityScript(entity); instance) {
+			*outInstance = *instance;
 		}
 	}
 

--- a/NuakeNet/src/Components.cs
+++ b/NuakeNet/src/Components.cs
@@ -22,7 +22,7 @@ namespace Nuake.Net
     }
     public class NameComponent : IComponent
     {
-        internal static unsafe delegate*<int, NativeString> GetNameIcall;
+        internal static unsafe delegate* unmanaged<int, NativeString> GetNameIcall;
 
         public NameComponent(int entityId)
         {
@@ -51,11 +51,11 @@ namespace Nuake.Net
 
     public class TransformComponent : IComponent
     {
-        internal static unsafe delegate*<int, NativeArray<float>> GetGlobalPositionIcall;
-        internal static unsafe delegate*<int, NativeArray<float>> GetPositionIcall;
-        internal static unsafe delegate*<int, float, float, float, void> SetPositionIcall;
-        internal static unsafe delegate*<int, float, float, float, float, float, float, void> LookAtIcall;
-        internal static unsafe delegate*<int, float, float, float, void> RotateIcall;
+        internal static unsafe delegate* unmanaged<int, NativeArray<float>> GetGlobalPositionIcall;
+        internal static unsafe delegate* unmanaged<int, NativeArray<float>> GetPositionIcall;
+        internal static unsafe delegate* unmanaged<int, float, float, float, void> SetPositionIcall;
+        internal static unsafe delegate* unmanaged<int, float, float, float, float, float, float, void> LookAtIcall;
+        internal static unsafe delegate* unmanaged<int, float, float, float, void> RotateIcall;
 
         public TransformComponent(int entityId)
         {
@@ -124,9 +124,9 @@ namespace Nuake.Net
 
     public class LightComponent : IComponent
     {
-        internal static unsafe delegate*<int, float> GetLightIntensityIcall;
-        internal static unsafe delegate*<int, float, void> SetLightIntensityIcall;
-        internal static unsafe delegate*<int, float, float, float, void> SetLightColorIcall;
+        internal static unsafe delegate* unmanaged<int, float> GetLightIntensityIcall;
+        internal static unsafe delegate* unmanaged<int, float, void> SetLightIntensityIcall;
+        internal static unsafe delegate* unmanaged<int, float, float, float, void> SetLightColorIcall;
         public enum LightType
         {
             Directional,
@@ -175,9 +175,9 @@ namespace Nuake.Net
 
     public class CameraComponent : IComponent
     {
-        internal static unsafe delegate*<int, NativeArray<float>> GetDirectionIcall;
-        internal static unsafe delegate*<int, float, void> SetCameraFOVIcall;
-        internal static unsafe delegate*<int, float> GetCameraFOVIcall;
+        internal static unsafe delegate* unmanaged<int, NativeArray<float>> GetDirectionIcall;
+        internal static unsafe delegate* unmanaged<int, float, void> SetCameraFOVIcall;
+        internal static unsafe delegate* unmanaged<int, float> GetCameraFOVIcall;
 
         public CameraComponent(int entityId)
         {
@@ -212,8 +212,8 @@ namespace Nuake.Net
 
     public class AudioEmitterComponent : IComponent
     {
-        internal static unsafe delegate*<int, bool> GetIsPlayingIcall;
-        internal static unsafe delegate*<int, bool, void> SetIsPlayingIcall;
+        internal static unsafe delegate* unmanaged<int, bool> GetIsPlayingIcall;
+        internal static unsafe delegate* unmanaged<int, bool, void> SetIsPlayingIcall;
 
         public AudioEmitterComponent(int entityId)
         {
@@ -243,7 +243,7 @@ namespace Nuake.Net
 
     public class SkinnedModelComponent : IComponent
     {
-        internal static unsafe delegate*<int, NativeString, void> PlayIcall;
+        internal static unsafe delegate* unmanaged<int, NativeString, void> PlayIcall;
 
         public SkinnedModelComponent(int entityId) 
         {
@@ -328,10 +328,10 @@ namespace Nuake.Net
 
     public class CharacterControllerComponent : IComponent
     {
-        internal static unsafe delegate*<int, float, float, float, void> MoveAndSlideIcall;
-        internal static unsafe delegate*<int, bool> IsOnGroundIcall;
-        internal static unsafe delegate*<int, NativeArray<float>> GetGroundVelocityIcall;
-        internal static unsafe delegate*<int, NativeArray<float>> GetGroundNormalIcall;
+        internal static unsafe delegate* unmanaged<int, float, float, float, void> MoveAndSlideIcall;
+        internal static unsafe delegate* unmanaged<int, bool> IsOnGroundIcall;
+        internal static unsafe delegate* unmanaged<int, NativeArray<float>> GetGroundVelocityIcall;
+        internal static unsafe delegate* unmanaged<int, NativeArray<float>> GetGroundNormalIcall;
 
         public CharacterControllerComponent(int entityId)
         {
@@ -401,7 +401,7 @@ namespace Nuake.Net
 
     public class NavMeshVolumeComponent : IComponent
     {
-        internal static unsafe delegate*<int, float, float, float, float, float, float, NativeArray<float>> FindPathIcall;
+        internal static unsafe delegate* unmanaged<int, float, float, float, float, float, float, NativeArray<float>> FindPathIcall;
 
         public NavMeshVolumeComponent(int entityId) {  EntityID = entityId; }
 

--- a/NuakeNet/src/EngineSubsystem.cs
+++ b/NuakeNet/src/EngineSubsystem.cs
@@ -2,8 +2,8 @@
 {
     public class EngineSubsystem
     {
-        internal static unsafe delegate*<int, bool, void> SetCanTickIcall;
-        internal static unsafe delegate*<int, bool> GetCanTickIcall;
+        internal static unsafe delegate* unmanaged<int, bool, void> SetCanTickIcall;
+        internal static unsafe delegate* unmanaged<int, bool> GetCanTickIcall;
     
         public int EngineSubsystemID { get; protected set; }
 

--- a/NuakeNet/src/Entity.cs
+++ b/NuakeNet/src/Entity.cs
@@ -22,15 +22,15 @@ namespace Nuake.Net
     [StructLayout(LayoutKind.Sequential)]
     public class Entity
     {
-        internal static unsafe delegate*<int, int, bool> EntityHasComponentIcall;
-        internal static unsafe delegate*<int, int, void> EntityAddComponentIcall;
-        internal static unsafe delegate*<int, bool> EntityHasManagedInstanceIcall;
-        internal static unsafe delegate*<int, NativeString, int> EntityGetEntityIcall;
-        internal static unsafe delegate*<int, NativeString> EntityGetNameIcall;
-        internal static unsafe delegate*<int, NativeString, void> EntitySetNameIcall;
-        internal static unsafe delegate*<int, bool> EntityIsValidIcall;
-        internal static unsafe delegate*<NativeString, NativeArray<int>> EntityGetTargetsIcall;
-        internal static unsafe delegate*<int, NativeString> EntityGetTargetIcall;
+        internal static unsafe delegate* unmanaged<int, int, bool> EntityHasComponentIcall;
+        internal static unsafe delegate* unmanaged<int, int, void> EntityAddComponentIcall;
+        internal static unsafe delegate* unmanaged<int, bool> EntityHasManagedInstanceIcall;
+        internal static unsafe delegate* unmanaged<int, NativeString, int> EntityGetEntityIcall;
+        internal static unsafe delegate* unmanaged<int, NativeString> EntityGetNameIcall;
+        internal static unsafe delegate* unmanaged<int, NativeString, void> EntitySetNameIcall;
+        internal static unsafe delegate* unmanaged<int, bool> EntityIsValidIcall;
+        internal static unsafe delegate* unmanaged<NativeString, NativeArray<int>> EntityGetTargetsIcall;
+        internal static unsafe delegate* unmanaged<int, NativeString> EntityGetTargetIcall;
 
         public enum ComponentTypes
         {
@@ -272,7 +272,7 @@ namespace Nuake.Net
 
     public class Prefab
     {
-        internal static unsafe delegate*<NativeString, Vector3, float, float, float, float, int> PrefabInstanceIcall;
+        internal static unsafe delegate* unmanaged<NativeString, Vector3, float, float, float, float, int> PrefabInstanceIcall;
 
         string Path {  get; set; }
 

--- a/NuakeNet/src/Environment.cs
+++ b/NuakeNet/src/Environment.cs
@@ -9,8 +9,8 @@ namespace Nuake.Net
 {
     public class Environment
     {
-        internal static unsafe delegate*<float, void> SetFocusDistanceIcall;
-        internal static unsafe delegate*<float> GetFocusDistanceIcall;
+        internal static unsafe delegate* unmanaged<float, void> SetFocusDistanceIcall;
+        internal static unsafe delegate* unmanaged<float> GetFocusDistanceIcall;
 
         public static void SetFocusDistance(float distance)
         {

--- a/NuakeNet/src/Input.cs
+++ b/NuakeNet/src/Input.cs
@@ -175,15 +175,15 @@ namespace Nuake.Net
 
     public class Input
     {
-        internal static unsafe delegate*<bool, void> ShowMouseIcall;
-        internal static unsafe delegate*<int, bool> IsKeyDownIcall;
-        internal static unsafe delegate*<int, bool> IsKeyPressedIcall;
-        internal static unsafe delegate*<int, bool> IsMouseButtonDownIcall;
-        internal static unsafe delegate*<NativeArray<float>> GetMousePositionIcall;
-        internal static unsafe delegate*<int, bool> IsControllerConnectedIcall;
-        internal static unsafe delegate*<int, NativeString> GetControllerNameIcall;
-        internal static unsafe delegate*<int, int, bool> IsControllerButtonPressedIcall;
-        internal static unsafe delegate*<int, int, float> GetControllerAxisIcall;
+        internal static unsafe delegate* unmanaged<bool, void> ShowMouseIcall;
+        internal static unsafe delegate* unmanaged<int, bool> IsKeyDownIcall;
+        internal static unsafe delegate* unmanaged<int, bool> IsKeyPressedIcall;
+        internal static unsafe delegate* unmanaged<int, bool> IsMouseButtonDownIcall;
+        internal static unsafe delegate* unmanaged<NativeArray<float>> GetMousePositionIcall;
+        internal static unsafe delegate* unmanaged<int, bool> IsControllerConnectedIcall;
+        internal static unsafe delegate* unmanaged<int, NativeString> GetControllerNameIcall;
+        internal static unsafe delegate* unmanaged<int, int, bool> IsControllerButtonPressedIcall;
+        internal static unsafe delegate* unmanaged<int, int, float> GetControllerAxisIcall;
 
 
         public static bool IsMouseButtonDown(MouseButton button)

--- a/NuakeNet/src/Physic.cs
+++ b/NuakeNet/src/Physic.cs
@@ -120,11 +120,11 @@ namespace Nuake.Net
             SENSORS = 5
         }
 
-        internal static unsafe delegate*<float, float, float, float, float, float, NativeArray<float>> RayCastIcall;
-        internal static unsafe delegate*<float, float, float, float, float, float, BoxInternal, NativeArray<float>> ShapeCastBoxIcall;
-        internal static unsafe delegate*<float, float, float, float, float, float, float, NativeArray<float>> ShapeCastSphereIcall;
-        internal static unsafe delegate*<float, float, float, float, float, float, CapsuleInternal, NativeArray<float>> ShapeCastCapsuleIcall;
-        internal static unsafe delegate*<float, float, float, float, float, float, CapsuleInternal, NativeArray<float>> ShapeCastCylinderIcall;
+        internal static unsafe delegate* unmanaged<float, float, float, float, float, float, NativeArray<float>> RayCastIcall;
+        internal static unsafe delegate* unmanaged<float, float, float, float, float, float, BoxInternal, NativeArray<float>> ShapeCastBoxIcall;
+        internal static unsafe delegate* unmanaged<float, float, float, float, float, float, float, NativeArray<float>> ShapeCastSphereIcall;
+        internal static unsafe delegate* unmanaged<float, float, float, float, float, float, CapsuleInternal, NativeArray<float>> ShapeCastCapsuleIcall;
+        internal static unsafe delegate* unmanaged<float, float, float, float, float, float, CapsuleInternal, NativeArray<float>> ShapeCastCylinderIcall;
 
         public static List<ShapeCastResult> RayCast(Vector3 from, Vector3 to)
         {

--- a/NuakeNet/src/Scene.cs
+++ b/NuakeNet/src/Scene.cs
@@ -6,10 +6,10 @@ namespace Nuake.Net
 {
     public class Scene
     {
-        internal static unsafe delegate*<NativeString, int> GetEntityIcall;
-        internal static unsafe delegate*<NativeString, NativeInstance<object>*, void> GetEntityScriptFromNameIcall;
-        internal static unsafe delegate*<int, NativeInstance<Entity>> GetEntityScriptFromHandleIcall;
-        internal static unsafe delegate*<NativeString, int> InstancePrefabIcall;
+        internal static unsafe delegate* unmanaged<NativeString, int> GetEntityIcall;
+        internal static unsafe delegate* unmanaged<NativeString, NativeInstance<object>*, void> GetEntityScriptFromNameIcall;
+        internal static unsafe delegate* unmanaged<int, NativeInstance<Entity>> GetEntityScriptFromHandleIcall;
+        internal static unsafe delegate* unmanaged<NativeString, int> InstancePrefabIcall;
 
         public static T? GetEntity<T>(string entityName) where T : class
         {

--- a/NuakeNet/src/UI/UIComponent.cs
+++ b/NuakeNet/src/UI/UIComponent.cs
@@ -78,16 +78,16 @@ namespace Nuake.Net
 
     public class Node
     {
-        internal static unsafe delegate*<NativeString, NativeString, NativeString, NativeString> FindChildByIDICall;
-        internal static unsafe delegate*<NativeString, NativeString, bool> HasNativeInstanceICall;
-        internal static unsafe delegate*<NativeString, NativeString, NativeInstance<Node>> GetNativeInstanceNodeICall;
-        internal static unsafe delegate*<NativeString, NativeString, Bool32, void> SetVisibilityICall;
-        internal static unsafe delegate*<NativeString, NativeString, Bool32> GetVisibilityICall;
+        internal static unsafe delegate* unmanaged<NativeString, NativeString, NativeString, NativeString> FindChildByIDICall;
+        internal static unsafe delegate* unmanaged<NativeString, NativeString, bool> HasNativeInstanceICall;
+        internal static unsafe delegate* unmanaged<NativeString, NativeString, NativeInstance<Node>> GetNativeInstanceNodeICall;
+        internal static unsafe delegate* unmanaged<NativeString, NativeString, Bool32, void> SetVisibilityICall;
+        internal static unsafe delegate* unmanaged<NativeString, NativeString, Bool32> GetVisibilityICall;
 
-        internal static unsafe delegate*<NativeString, NativeString, float> GetHeightPercentageICall;
-        internal static unsafe delegate*<NativeString, NativeString, float, void> SetHeightPercentageICall;
-        internal static unsafe delegate*<NativeString, NativeString, float> GetWidthPercentageICall;
-        internal static unsafe delegate*<NativeString, NativeString, float, void> SetWidthPercentageICall;
+        internal static unsafe delegate* unmanaged<NativeString, NativeString, float> GetHeightPercentageICall;
+        internal static unsafe delegate* unmanaged<NativeString, NativeString, float, void> SetHeightPercentageICall;
+        internal static unsafe delegate* unmanaged<NativeString, NativeString, float> GetWidthPercentageICall;
+        internal static unsafe delegate* unmanaged<NativeString, NativeString, float, void> SetWidthPercentageICall;
 
         public string UUID;
         public string CanvasUUID;
@@ -202,8 +202,8 @@ namespace Nuake.Net
 
     public class TextNode : Node
     {
-        internal static unsafe delegate*<NativeString, NativeString, NativeString, void> SetTextNodeTextICall;
-        internal static unsafe delegate*<NativeString, NativeString, NativeString> GetTextNodeTextICall;
+        internal static unsafe delegate* unmanaged<NativeString, NativeString, NativeString, void> SetTextNodeTextICall;
+        internal static unsafe delegate* unmanaged<NativeString, NativeString, NativeString> GetTextNodeTextICall;
 
         public string Text 
         { 

--- a/NuakeNet/src/main.cs
+++ b/NuakeNet/src/main.cs
@@ -17,9 +17,9 @@ namespace Nuake.Net
     /// </summary>
     public class Engine
     {
-        internal static unsafe delegate*<NativeString, void> LoggerLogIcall;
-        internal static unsafe delegate*<NativeString, void> LoadSceneIcall;
-        internal static unsafe delegate*<NativeString, NativeInstance<EngineSubsystem>> GetSubsystemByNameIcall;
+        internal static unsafe delegate* unmanaged<NativeString, void> LoggerLogIcall;
+        internal static unsafe delegate* unmanaged<NativeString, void> LoadSceneIcall;
+        internal static unsafe delegate* unmanaged<NativeString, NativeInstance<EngineSubsystem>> GetSubsystemByNameIcall;
         
         public Engine() { }
 
@@ -147,14 +147,14 @@ namespace Nuake.Net
 
     public class Debug
     {
-        internal static unsafe delegate*</* start */ float, float, float,
+        internal static unsafe delegate* unmanaged</* start */ float, float, float,
                                          /* end */   float, float, float,
                                          /* color */ float, float, float, float,
                                         /* life */   float,
                                                      float,
                                                      void> DrawLineIcall;
 
-        internal static unsafe delegate*</* position */ Vector3,
+        internal static unsafe delegate* unmanaged</* position */ Vector3,
                                          /* rotation */ Quaternion,
                                          /* shape */    Vector3,
                                          /* color */    Vector4,
@@ -162,7 +162,7 @@ namespace Nuake.Net
                                                         float,
                                                         void> DrawShapeBoxIcall;
 
-        internal static unsafe delegate*</* position */ Vector3,
+        internal static unsafe delegate* unmanaged</* position */ Vector3,
                                          /* rotation */ Quaternion,
                                          /* shape */    float,
                                          /* color */    Vector4,
@@ -170,7 +170,7 @@ namespace Nuake.Net
                                                         float,
                                                         void> DrawShapeSphereIcall;
 
-        internal static unsafe delegate*</* position */ Vector3,
+        internal static unsafe delegate* unmanaged</* position */ Vector3,
                                          /* rotation */ Quaternion,
                                          /* shape */    float, float,
                                          /* color */    Vector4,
@@ -178,7 +178,7 @@ namespace Nuake.Net
                                                         float,
                                                         void> DrawShapeCylinderIcall;
 
-        internal static unsafe delegate*</* position */ Vector3,
+        internal static unsafe delegate* unmanaged</* position */ Vector3,
                                          /* rotation */ Quaternion,
                                          /* shape */    float, float,
                                          /* color */    Vector4,


### PR DESCRIPTION
delegates into unmanaged code are now marked with unmanaged keyword
Fixes "Invalid Program: attempted to call a UnmanagedCallersOnly method from managed code" when a game script tries to get another entity, as in   var camera = GetEntity\<Camera\>("camera");